### PR TITLE
Remove custom task template from memory

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloud.java
@@ -376,6 +376,14 @@ public class ECSCloud extends Cloud {
         TaskTemplateMap.get().removeTemplate(this, t);
     }
 
+    /**
+     * Remove a dynamic task template from the template map.
+     * @param t the template to remove
+     */
+    public void removeDynamicTemplateFromTemplateMap(ECSTaskTemplate t) {
+        TaskTemplateMap.get().removeTemplate(this, t);
+    }
+
     @Extension
     public static class DescriptorImpl extends Descriptor<Cloud> {
         public static final int DEFAULT_RETENTION_TIMEOUT = 5;

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecution.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecution.java
@@ -187,7 +187,7 @@ public class ECSTaskTemplateStepExecution extends AbstractStepExecutionImpl {
                 if (override != null){
                     LOGGER.log(Level.INFO, "Remove custom task template from map, not cloud {0}",
                         new Object[] { c.name});
-		    ecsCloud.removeDynamicTemplateFromTemplateMap(taskTemplate);
+                    ecsCloud.removeDynamicTemplateFromTemplateMap(taskTemplate);
                     return;
                 } else {
                     LOGGER.log(Level.INFO, "Removing task template {1} from cloud {0}",

--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecution.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/ECSTaskTemplateStepExecution.java
@@ -185,8 +185,9 @@ public class ECSTaskTemplateStepExecution extends AbstractStepExecutionImpl {
             if (c instanceof ECSCloud) {
                 ECSCloud ecsCloud = (ECSCloud) c;
                 if (override != null){
-                    LOGGER.log(Level.INFO, "Do not remove custom task template from cloud {0}",
+                    LOGGER.log(Level.INFO, "Remove custom task template from map, not cloud {0}",
                         new Object[] { c.name});
+		    ecsCloud.removeDynamicTemplateFromTemplateMap(taskTemplate);
                     return;
                 } else {
                     LOGGER.log(Level.INFO, "Removing task template {1} from cloud {0}",


### PR DESCRIPTION
Failure to remove this task template leaves it around in Jenkins's memory, leaking over time. In the case of a pipeline job creating different labels per job run, this memory leak will happen quickly. 

Also, when Jenkins asks the plugin, "can you provision this label?" the response will slow down over time as template map grows.