### PR TITLE
SYS-7592 - Fix thread-safety bug in TaskTemplateMap

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/TaskTemplateMap.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/amazonecs/pipeline/TaskTemplateMap.java
@@ -53,12 +53,16 @@ public class TaskTemplateMap {
      * @param TaskTemplate The pod template to add.
      */
     public void addTemplate(@Nonnull ECSCloud cloud, @Nonnull ECSTaskTemplate TaskTemplate) {
-        List<ECSTaskTemplate> list = getOrCreateTemplateList(cloud);
-        list.add(TaskTemplate);
-        map.put(cloud.name, list);
+        synchronized (this.map) {
+            List<ECSTaskTemplate> list = getOrCreateTemplateList(cloud);
+            list.add(TaskTemplate);
+            map.put(cloud.name, list);
+        }
     }
 
     public void removeTemplate(@Nonnull ECSCloud cloud, @Nonnull ECSTaskTemplate TaskTemplate) {
-        getOrCreateTemplateList(cloud).remove(TaskTemplate);
+        synchronized (this.map) {
+            getOrCreateTemplateList(cloud).remove(TaskTemplate);
+        }
     }
 }


### PR DESCRIPTION
## Addresses
- [SYS-7592](https://deepfield.atlassian.net/browse/SYS-7592)

## The Problem
`TaskTemplateMap.addTemplate` is not thread-safe. The `getOrCreateTemplateList` → `list.add` → `map.put` sequence is three separate steps that can be interleaved by concurrent threads. When parallel matrix branches register `ecsTaskTemplate` simultaneously, one template can be silently lost, causing `node(label)` to either fall back to a stale static template (wrong container) or hang with "All nodes offline."

Reproduced on our Jenkins (v1.49): 830/1000 iterations lost at least one template.

## Why This Solution?
The Kubernetes plugin had the identical bug in `PodTemplateMap` (the ECS plugin's `TaskTemplateMap` was copied from it) and fixed it in 2019 ([commit f241781](https://github.com/jenkinsci/kubernetes-plugin/commit/f2417811483b43951594984aedfcacc5ccf5d958)) by wrapping the methods in `synchronized (this.map)`. This applies the same fix.

After patching: 0/1000 iterations lost templates.

----
### How this was tested
- Reproduced the race condition using a Jenkins Script Console test with `CountDownLatch` to force concurrent `addTemplate` calls
- **Before (unpatched v1.49):** 830/1000 iterations lost templates (83%)
- **After (patched):** 0/1000 iterations lost templates (0%)
- Tested on a local Docker Jenkins matching prod version (2.528.3-lts)

[SYS-7592]: https://deepfield.atlassian.net/browse/SYS-7592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ